### PR TITLE
Fix error handling when regenerating messages

### DIFF
--- a/src/lib/components/chat-history/utils/regenerateMessage.ts
+++ b/src/lib/components/chat-history/utils/regenerateMessage.ts
@@ -151,7 +151,7 @@ export async function regenerateMessage(messageId: number) {
 		});
 
 		if (!streamResponse.ok) {
-			const errorData = await response.clone().json();
+			const errorData = await streamResponse.clone().json();
 			// Clone the response so that we can safely read it as JSON
 			if (errorData.message === 'Insufficient balance') {
 				// errorPopup.showError(


### PR DESCRIPTION
## Summary
- fix typo in regenerateMessage so the error data is read from the correct response
- apply Prettier formatting for regenerateMessage

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`
